### PR TITLE
Allow variable substitution with ${workspaceFolder} in libPaths config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ in `settings.json`:
   `jsonnetfmt` executable, if it's not on the `PATH`. (NOTE: This setting
   is always necessary on Windows.)
 * `jsonnet.libPaths`: Additional paths to search for libraries when compiling Jsonnet code.
+  It suppports variable substitution: `${workspaceFolder}`.
 * `jsonnet.outputFormat`: Preview output format: yaml or json (default is yaml).
 * `jsonnet.extStrs`: External strings to pass to `jsonnet` executable.
 

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -118,6 +118,10 @@ namespace workspace {
         .map(key => `--ext-str ${key}="${extStrsObj[key]}"`)
         .join(" ");
   }
+  
+  const expandPathVariables = (path: string): string => {
+    return path.replace(/\${workspaceFolder}/g, vs.workspace.workspaceFolders?.[0].uri.fsPath);
+  }
 
   export const libPaths = (): string => {
     const libPaths = vs.workspace.getConfiguration('jsonnet')["libPaths"];
@@ -138,8 +142,8 @@ namespace workspace {
     if (jsonnetExecutable != null) {
       (<string[]>libPaths).unshift(jsonnetExecutable);
     }
-
     return libPaths
+      .map(path => expandPathVariables(path))
       .map(path => `-J ${path}`)
       .join(" ");
   }

--- a/server/server.ts
+++ b/server/server.ts
@@ -136,7 +136,6 @@ export const initializer = (
 export const configUpdateProvider = (
   change: server.DidChangeConfigurationParams,
 ): void => {
-  console.log(change);
   if (
     change.settings == null || change.settings.jsonnet == null ||
     change.settings.jsonnet.libPaths == null
@@ -164,28 +163,28 @@ const positionToLocation = (
 const completionInfoToCompletionItem = (
   completionInfo: editor.CompletionInfo
 ): server.CompletionItem => {
-    let kindMapping: server.CompletionItemKind;
-    switch (completionInfo.kind) {
-      case "Field": {
-        kindMapping = server.CompletionItemKind.Field;
-        break;
-      }
-      case "Variable": {
-        kindMapping = server.CompletionItemKind.Variable;
-        break;
-      }
-      case "Method": {
-        kindMapping = server.CompletionItemKind.Method;
-        break;
-      }
-      default: throw new Error(
-        `Unrecognized completion type '${completionInfo.kind}'`);
+  let kindMapping: server.CompletionItemKind;
+  switch (completionInfo.kind) {
+    case "Field": {
+      kindMapping = server.CompletionItemKind.Field;
+      break;
     }
+    case "Variable": {
+      kindMapping = server.CompletionItemKind.Variable;
+      break;
+    }
+    case "Method": {
+      kindMapping = server.CompletionItemKind.Method;
+      break;
+    }
+    default: throw new Error(
+      `Unrecognized completion type '${completionInfo.kind}'`);
+  }
 
-    // Black magic type coercion. This allows us to avoid doing a
-    // deep copy over to a new `CompletionItem` object, and
-    // instead only re-assign the `kindMapping`.
-    const completionItem = (<server.CompletionItem>(<object>completionInfo));
-    completionItem.kind = kindMapping;
-    return completionItem;
+  // Black magic type coercion. This allows us to avoid doing a
+  // deep copy over to a new `CompletionItem` object, and
+  // instead only re-assign the `kindMapping`.
+  const completionItem = (<server.CompletionItem>(<object>completionInfo));
+  completionItem.kind = kindMapping;
+  return completionItem;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -136,6 +136,7 @@ export const initializer = (
 export const configUpdateProvider = (
   change: server.DidChangeConfigurationParams,
 ): void => {
+  console.log(change);
   if (
     change.settings == null || change.settings.jsonnet == null ||
     change.settings.jsonnet.libPaths == null


### PR DESCRIPTION
This allows us to add workspace relative paths to libPaths.