### PR TITLE
[Bugfix] Look for path without percentage encode

### DIFF
--- a/compiler/editor/workspace.ts
+++ b/compiler/editor/workspace.ts
@@ -124,6 +124,9 @@ export abstract class LibPathResolver {
     if (!parsed || !parsed.path || parsed.protocol !== "file:") {
       throw new Error(`INTERNAL ERROR: Failed to parse URI '${fileSpec}'`);
     }
+    parsed.path = url.fileURLToPath(importPath)
+    parsed.pathname = url.fileURLToPath(importPath)
+
     return parsed;
   }
 

--- a/server/local.ts
+++ b/server/local.ts
@@ -102,6 +102,8 @@ export class VsCompilerService implements _static.LexicalAnalyzerService {
     if (!parsedUrl || !parsedUrl.path) {
       throw new Error(`INTERNAL ERROR: Failed to parse URI '${fileUri}'`);
     }
+    parsedUrl.path = url.fileURLToPath(fileUri)
+    parsedUrl.pathname = url.fileURLToPath(fileUri)
 
     const lex = lexer.Lex(parsedUrl.path, text);
     if (lexical.isStaticError(lex)) {

--- a/site/main.ts
+++ b/site/main.ts
@@ -119,6 +119,8 @@ export class BrowserCompilerService implements _static.LexicalAnalyzerService {
     if (!parsedUrl || !parsedUrl.path) {
       throw new Error(`INTERNAL ERROR: Failed to parse URI '${fileUri}'`);
     }
+    parsedUrl.path = url.fileURLToPath(fileUri)
+    parsedUrl.pathname = url.fileURLToPath(fileUri)
 
     const lex = lexer.Lex(parsedUrl.path, text);
     if (lexical.isStaticError(lex)) {


### PR DESCRIPTION
Bugfix:
When import jsonnet path contains special character, `fs.statSync(url.parse(fileUri).path)` is still percentage encoded, should use logic `fs.statSync(url.fileURLToPath(fileUri))`

Reproduce:
https://github.com/loynoir/reproduce-vscode-jsonnet.jsonnet
