### PR TITLE
Add support for TLA arguments being passed to jsonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ in `settings.json`:
   It suppports variable substitution: `${workspaceFolder}`.
 * `jsonnet.outputFormat`: Preview output format: yaml or json (default is yaml).
 * `jsonnet.extStrs`: External strings to pass to `jsonnet` executable.
+* `jsonnet.tlaStrs`: Top-level arguments to pass to `jsonnet` executable as strings.
+* `jsonnet.tlaCodes`: Top-level arguments to pass to `jsonnet` executable as code.
 
 This extension exposes the following commands, which can be bound to
 keys:
@@ -66,6 +68,16 @@ keys:
 * `jsonnet.extStrs`: An object of variable, value pairs. Allows you to
   customize the external variables passed to the `jsonnet` command
   line. It can be particularly useful to set this in a workspace
+  configuration, so that you can set different variables on a
+  per-project basis.
+* `jsonnet.tlaStrs`: An object of variable, value pairs. Allows you to
+  customize the top level arguments passed to the `jsonnet` command
+  line as strings. It can be particularly useful to set this in a workspace
+  configuration, so that you can set different variables on a
+  per-project basis.
+* `jsonnet.tlaCodes`: An object of variable, value pairs. Allows you to
+  customize the top level arguments passed to the `jsonnet` command
+  line as jsonnet code. It can be particularly useful to set this in a workspace
   configuration, so that you can set different variables on a
   per-project basis.
 * `jsonnet.outputFormat`: A choice of two string literals: `["json",

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -107,7 +107,9 @@ namespace register {
 }
 
 namespace workspace {
-  const extStrsProp = "extStrs";
+  const extStrsProp  = "extStrs";
+  const tlaStrsProp  = "tlaStrs";
+  const tlaCodesProp = "tlaCodes";
   const execPathProp = "executablePath";
 
   export const extStrs = (): string => {
@@ -118,7 +120,25 @@ namespace workspace {
         .map(key => `--ext-str ${key}="${extStrsObj[key]}"`)
         .join(" ");
   }
-  
+
+  export const tlaStrs = (): string => {
+    const tlaStrsObj = vs.workspace.getConfiguration('jsonnet')[tlaStrsProp];
+    return tlaStrsObj == null
+      ? ""
+      : Object.keys(tlaStrsObj)
+        .map(key => `--tla-str ${key}="${tlaStrsObj[key]}"`)
+        .join(" ");
+  }
+
+  export const tlaCodes = (): string => {
+    const tlaCodesObj = vs.workspace.getConfiguration('jsonnet')[tlaCodesProp];
+    return tlaCodesObj == null
+      ? ""
+      : Object.keys(tlaCodesObj)
+        .map(key => `--tla-code ${key}="${tlaCodesObj[key]}"`)
+        .join(" ");
+  }
+
   const expandPathVariables = (path: string): string => {
     return path.replace(/\${workspaceFolder}/g, vs.workspace.workspaceFolders?.[0].uri.fsPath);
   }
@@ -365,10 +385,12 @@ namespace jsonnet {
 
       try {
         // Compile the preview Jsonnet file.
-        const extStrs = workspace.extStrs();
+        const extStrs  = workspace.extStrs();
+        const tlaStrs  = workspace.tlaStrs();
+        const tlaCodes = workspace.tlaCodes();
         const libPaths = workspace.libPaths();
         const jsonOutput = execSync(
-          `${jsonnet.executable} ${libPaths} ${extStrs} ${codePaths} ${sourceFile}`
+          `${jsonnet.executable} ${libPaths} ${extStrs} ${tlaStrs} ${tlaCodes} ${codePaths} ${sourceFile}`
         ).toString();
 
         // Cache.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,16 @@
           "description": "External strings to pass to `jsonnet` executable.",
           "type": "object"
         },
+        "jsonnet.tlaStrs": {
+          "default": null,
+          "description": "Top-level arguments to pass to `jsonnet` executable as strings.",
+          "type": "object"
+        },
+        "jsonnet.tlaCodes": {
+          "default": null,
+          "description": "Top-level arguments to pass to `jsonnet` executable as code.",
+          "type": "object"
+        },
         "jsonnet.libPaths": {
           "default": [],
           "description": "Additional paths to search for libraries when compiling Jsonnet code.",

--- a/package.jsonnet
+++ b/package.jsonnet
@@ -59,6 +59,10 @@ package.contributes.DefaultConfiguration(
     "Additional paths to search for libraries when compiling Jsonnet code.") +
   contributes.configuration.DefaultObjectProperty(
     "jsonnet.extStrs", "External strings to pass to `jsonnet` executable.") +
+  contributes.configuration.DefaultObjectProperty(
+    "jsonnet.tlaStrs", "Top-level arguments to pass to `jsonnet` executable as strings.") +
+  contributes.configuration.DefaultObjectProperty(
+    "jsonnet.tlaCodes", "Top-level arguments to pass to `jsonnet` executable as code.") +
   contributes.configuration.DefaultEnumProperty(
     "jsonnet.outputFormat",
     "Preview output format (yaml / json)",


### PR DESCRIPTION
Top-level Argument (TLA) support has been added to `jsonnet` and allows the user to create functions that are passed these arguments directly from the executable. This adds support for configuring those TLAs in the workspace and global settings for easier testing of jsonnet templates.